### PR TITLE
refactor: packet_info의 필드값이 None인 경우 필드 자체를 보내지 않도록 변경

### DIFF
--- a/wavnes/packet_handlers.py
+++ b/wavnes/packet_handlers.py
@@ -49,14 +49,14 @@ class MQTTHandler(PacketHandler):
             self.packet_info['connect'] = {
                 'proto_name': str(mqtt_packet.protoname),
                 'mqtt_level': str(PROTOCOL_LEVEL.get(mqtt_packet.protolevel, "Unknown")),
-                'usernameflag': str(mqtt_packet.usernameflag),
-                'passwordflag': str(mqtt_packet.passwordflag),
-                'willretainflag': str(mqtt_packet.willretainflag),
-                'willQOSflag': str(mqtt_packet.willQOSflag),
-                'willflag': str(mqtt_packet.willflag),
-                'cleansession': str(mqtt_packet.cleansess),
-                'reserved': str(mqtt_packet.reserved),
-                'keep_alive': str(mqtt_packet.klive),
+                'usernameflag': int(mqtt_packet.usernameflag),
+                'passwordflag': int(mqtt_packet.passwordflag),
+                'willretainflag': int(mqtt_packet.willretainflag),
+                'willQOSflag': int(mqtt_packet.willQOSflag),
+                'willflag': int(mqtt_packet.willflag),
+                'cleansession': int(mqtt_packet.cleansess),
+                'reserved': int(mqtt_packet.reserved),
+                'keep_alive': int(mqtt_packet.klive) if mqtt_packet.klive is not None else None,
                 'clientId': str(mqtt_packet.clientId),
             }
             if mqtt_packet.willflag:
@@ -69,20 +69,22 @@ class MQTTHandler(PacketHandler):
 
         elif packet_type == 'CONNACK':
             self.packet_info['connack'] = {
-                'ackflag': str(mqtt_packet.sessPresentFlag),
-                'return_code': str(mqtt_packet.retcode),
+                'ackflag': int(mqtt_packet.sessPresentFlag),
+                'return_code': int(mqtt_packet.retcode) if mqtt_packet.retcode is not None else None,
             }
 
         elif packet_type == 'PUBLISH':
-            self.packet_info['publish'] = {
+            publish_info = {
                 'topic': str(mqtt_packet.topic),
-                'msgid': str(mqtt_packet.msgid),
                 'msgvalue': str(mqtt_packet.value),
             }
+            if mqtt_packet.msgid is not None:
+                publish_info['msgid'] = int(mqtt_packet.msgid)
+            self.packet_info['publish'] = publish_info
 
         elif packet_type in ['PUBACK', 'PUBREC', 'PUBREL', 'PUBCOMP']:
             self.packet_info[packet_type.lower()] = {
-                'msgid': str(mqtt_packet.msgid),
+                'msgid': int(mqtt_packet.msgid),
             }
 
         elif packet_type == 'SUBSCRIBE':
@@ -90,29 +92,30 @@ class MQTTHandler(PacketHandler):
             for topic_filter in mqtt_packet.topics:
                 topic_filters.append({
                     'topic': topic_filter.topic.decode('utf-8'),
-                    'qos': str(topic_filter.QOS),
+                    'qos': topic_filter.QOS,
                 })
             self.packet_info['subscribe'] = {
-                'msgid': str(mqtt_packet.msgid),
+                'msgid': int(mqtt_packet.msgid),
                 'topic_filters': topic_filters,
             }
 
         elif packet_type == 'SUBACK':
             self.packet_info['suback'] = {
-                'msgid': str(mqtt_packet.msgid),
-                'return_code': str(mqtt_packet.retcode),
+                'msgid': int(mqtt_packet.msgid),
+                'return_code': int(mqtt_packet.retcode),
             }
 
         elif packet_type == 'UNSUBSCRIBE':
             topic_filters = [topic_filter.decode('utf-8') for topic_filter in mqtt_packet.topics]
             self.packet_info['unsubscribe'] = {
-                'msgid': str(mqtt_packet.msgid),
+                'msgid': int(mqtt_packet.msgid),
                 'topic_filters': topic_filters,
             }
 
         elif packet_type == 'UNSUBACK':
             self.packet_info['unsuback'] = {
-                'msgid': str(mqtt_packet.msgid),
+                'msgid': int(mqtt_packet.msgid),
             }
 
+    def get_packet_info(self):
         return self.packet_info


### PR DESCRIPTION
## Issue
#21 

## Details
scapy에 선언된 자료형이 int인 변수를 처리하는 경우,
서버에서도 str 값이 아닌 int 값으로 처리를 하고, None인 경우 필드 자체를 생성하지 않도록 변경

<img width="452" alt="image" src="https://github.com/Wave-Net/wavenet-backend/assets/52701529/56977585-b487-4fae-9efb-b76c76601cec">