### PR TITLE
fix: source, destination ip를 모든 레이어에서 지정할 수 있도록 변경

### DIFF
--- a/wavnes/packet_handlers.py
+++ b/wavnes/packet_handlers.py
@@ -17,12 +17,36 @@ def packet_time_info(start_time, previous_time, packet):
 class PacketHandler(ABC):
     def __init__(self, packet):
         self.packet_info = {
-            'source_ip': str(packet[IP].src),
-            'destination_ip': str(packet[IP].dst),
-            'source_port': int(packet[TCP].sport),
-            'destination_port': int(packet[TCP].dport),
-            'length': int(packet.len)
+            'source_ip': self._get_source_ip(packet),
+            'destination_ip': self._get_destination_ip(packet),
+            'length': len(packet),
         }
+
+    @staticmethod
+    def _get_source_ip(packet):
+        if IP in packet:
+            return packet[IP].src
+        elif IPv6 in packet:
+            return packet[IPv6].src
+        elif ARP in packet:
+            return packet[ARP].psrc
+        elif DHCP in packet:
+            return packet[DHCP].ciaddr
+        else:
+            return None
+
+    @staticmethod
+    def _get_destination_ip(packet):
+        if IP in packet:
+            return packet[IP].dst
+        elif IPv6 in packet:
+            return packet[IPv6].dst
+        elif ARP in packet:
+            return packet[ARP].pdst
+        elif DHCP in packet:
+            return packet[DHCP].siaddr
+        else:
+            return None
 
     @abstractmethod
     def process_packet(self, packet):


### PR DESCRIPTION
## Issue
#28 

## Details
source_ip, destination_ip, length만 PacketHandler 클래스에서 지정할 수 있도록 변경.
port는 일단 뺐음.
source_ip, destination_ip를 정하는 코드는 아래 기준을 참고

### scapy의 Packet 객체의 src, dst 정리
Scapy에서 소스 IP와 목적지 IP를 알 수 있는 주요 레이어는 다음과 같습니다:

1. `IP` 레이어:
   - 소스 IP: `packet[IP].src`
   - 목적지 IP: `packet[IP].dst`

2. `IPv6` 레이어:
   - 소스 IP: `packet[IPv6].src`
   - 목적지 IP: `packet[IPv6].dst`

3. `TCP` 레이어:
   - 소스 IP: `packet[IP].src` (TCP는 IP 레이어 위에 있으므로 IP 레이어에서 가져옴)
   - 목적지 IP: `packet[IP].dst`

4. `UDP` 레이어:
   - 소스 IP: `packet[IP].src` (UDP는 IP 레이어 위에 있으므로 IP 레이어에서 가져옴)
   - 목적지 IP: `packet[IP].dst`

5. `ICMP` 레이어:
   - 소스 IP: `packet[IP].src` (ICMP는 IP 레이어 위에 있으므로 IP 레이어에서 가져옴)
   - 목적지 IP: `packet[IP].dst`

6. `ARP` 레이어:
   - 송신자 IP: `packet[ARP].psrc`
   - 타깃 IP: `packet[ARP].pdst`

7. `DHCP` 레이어:
   - 클라이언트 IP: `packet[DHCP].ciaddr`
   - 서버 IP: `packet[DHCP].siaddr`
   - 할당된 IP: `packet[DHCP].yiaddr`

8. `DNS` 레이어:
   - 질의자 IP: `packet[IP].src` (DNS는 일반적으로 UDP 또는 TCP 위에서 동작하므로 IP 레이어에서 가져옴)
   - 응답자 IP: `packet[IP].dst`

위의 레이어들은 일반적으로 소스 IP와 목적지 IP를 포함하고 있습니다. 각 레이어마다 IP 주소를 나타내는 필드 이름이 다를 수 있으므로 해당 레이어의 문서를 참조하는 것이 좋습니다.

`PacketHandler` 클래스에서는 `IP`, `IPv6`, `UDP` 레이어를 사용하여 소스 IP와 목적지 IP를 가져오고 있습니다. 필요에 따라 다른 레이어를 추가하거나 수정할 수 있습니다.

패킷을 처리할 때는 해당 패킷에 원하는 레이어가 존재하는지 확인한 후에 접근해야 합니다. `if LayerName in packet` 형식으로 레이어의 존재 여부를 확인할 수 있습니다.

예를 들어, TCP 패킷의 경우 `if IP in packet and TCP in packet`으로 확인한 후에 소스 IP와 목적지 IP를 가져올 수 있습니다.