### PR TITLE
refactor: packet 정보 관련 클래스 파일 따로 구분

### DIFF
--- a/wavnes/info.py
+++ b/wavnes/info.py
@@ -1,0 +1,54 @@
+import time
+
+
+class PacketTimeInfo:
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.index = 0
+        self.start_time = time.time()
+        self.prev_time = 0.0
+        self.curr_time = 0.0
+
+    def update(self, packet):
+        self.index += 1
+        self.prev_time = self.curr_time
+        self.curr_time = packet.time
+
+    def get_time_info(self):
+        return {
+            'index': self.index,
+            'timestamp': '{:.6f}'.format(self.curr_time),
+            'time_of_day': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.curr_time)),
+            'seconds_since_beginning': '{:.6f}'.format(float(self.curr_time - self.start_time)),
+            'seconds_since_previous': '{:.6f}'.format(float(self.curr_time - self.prev_time)),
+        }
+
+
+class PacketStatInfo:
+    def __init__(self, target_ip):
+        self.target_ip = target_ip
+        self.reset()
+
+    def reset(self):
+        self.cur_stat = {'send_pkt': 0, 'recv_pkt': 0,
+                         'send_data': 0, 'recv_data': 0}
+
+    def update(self, src, dst, data):
+        if src == self.target_ip:
+            self.cur_stat['send_pkt'] += 1
+            self.cur_stat['send_data'] += data
+            return
+        if dst == self.target_ip:
+            self.cur_stat['recv_pkt'] += 1
+            self.cur_stat['recv_data'] += data
+
+    @staticmethod
+    def get_delta(cur_stat, prev_stat):
+        delta = {key: cur_stat[key] - prev_stat[key]
+                 for key in cur_stat}
+        return delta
+
+    def get_total(self):
+        return self.cur_stat.copy()

--- a/wavnes/sniffer.py
+++ b/wavnes/sniffer.py
@@ -122,7 +122,7 @@ class Sniffer:
             self.is_running = True
 
         try:
-            sniff(prn=self._packet_callback, stop_filter=stop_filter)
+            sniff(prn=self._packet_callback, stop_filter=stop_filter, store=False)
         except Exception as e:
             print(f"Error in sniff: {e}")
         finally:


### PR DESCRIPTION
PacketTimeInfo, PacketStatInfo 로 시간, 패킷 통계 관리하던 객체명 바꾸고 info.py로 이동