### PR TITLE
refactor: PacketStatsMonitor 말고 PacketStatsSender로 이름 변경

### DIFF
--- a/wavnes/__init__.py
+++ b/wavnes/__init__.py
@@ -1,5 +1,5 @@
 from wavnes.network_monitor import NetworkMonitor
-from wavnes.packet_stats_monitor import PacketStatsMonitor
+from wavnes.packet_stats_sender import PacketStatsSender
 from wavnes.packet_capturer import PacketCapturer
 from wavnes.device import Device
 from wavnes.sniffer import Sniffer

--- a/wavnes/main.py
+++ b/wavnes/main.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from wavnes.network_monitor import NetworkMonitor
-from wavnes.packet_stats_monitor import PacketStatsMonitor
+from wavnes.packet_stats_sender import PacketStatsSender
 from wavnes.packet_capturer import PacketCapturer
 
 app = FastAPI()
@@ -17,10 +17,10 @@ async def websocket_endpoint(websocket: WebSocket):
 
     try:
         loop = asyncio.get_event_loop()
-        stats_monitor = PacketStatsMonitor(network_monitor, websocket)
+        stats_sender = PacketStatsSender(network_monitor, websocket)
         packet_capturer = PacketCapturer(network_monitor, websocket, loop)
 
-        await stats_monitor.start()
+        await stats_sender.start()
 
         while True:
             message = await websocket.receive_text()
@@ -34,11 +34,11 @@ async def websocket_endpoint(websocket: WebSocket):
 
     except WebSocketDisconnect:
         packet_capturer.stop()
-        await stats_monitor.stop()
+        await stats_sender.stop()
 
     except Exception as e:
         print(f"Error: {e}")
 
     finally:
         packet_capturer.stop()
-        await stats_monitor.stop()
+        await stats_sender.stop()

--- a/wavnes/packet_stats_sender.py
+++ b/wavnes/packet_stats_sender.py
@@ -1,7 +1,7 @@
 import asyncio
 
 
-class PacketStatsMonitor:
+class PacketStatsSender:
     def __init__(self, network_monitor, websocket):
         self.network_monitor = network_monitor
         self.websocket = websocket


### PR DESCRIPTION
- NetworkMonitor에서 스니핑은 계속 이뤄지고
- PacketStatsSender에서는 통계를 보내는 역할만 함