### PR TITLE
fix: 웹소켓 연결 끊길 때마다 network_monitor reset 되지 않도록 변경 #55

### DIFF
--- a/wavnes/packet_stats_sender.py
+++ b/wavnes/packet_stats_sender.py
@@ -19,7 +19,6 @@ class PacketStatsSender:
             except asyncio.CancelledError:
                 pass
             self.monitoring_task = None
-        self.network_monitor.reset()
 
     async def _monitoring_loop(self):
         while True:


### PR DESCRIPTION
## Issues
#55

## Details
 