### PR TITLE
feat: 네트워크 모니터링 웹소켓 연결시에만 하지 말고 애플리케이션 단에서 하도록 정확히 분리 #60

### DIFF
--- a/wavnes/main.py
+++ b/wavnes/main.py
@@ -1,14 +1,25 @@
 import asyncio
 import json
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from contextlib import asynccontextmanager
 from wavnes.network_monitor import NetworkMonitor
 from wavnes.monitoring_data_sender import MonitoringDataSender
 from wavnes.packet_data_sender import PacketDataSender
 
-app = FastAPI()
-
 
 network_monitor = NetworkMonitor('en0')
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await network_monitor.start()
+    try:
+        yield
+    finally:
+        pass
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.websocket("/capture")
@@ -19,24 +30,30 @@ async def websocket_endpoint(websocket: WebSocket):
         loop = asyncio.get_event_loop()
         sender = PacketDataSender(network_monitor, websocket, loop)
 
+        device_ip = '192.168.55.30'
+        device = network_monitor.get_device_by_ip(device_ip)
+        print(device.ip)
+
+        await sender.start(device)
+
         while True:
             message = await websocket.receive_text()
-            data = json.loads(message)
-            if data["type"] == "start_capture":
-                device_ip = data["device_ip"]
-                device = network_monitor.get_device_by_ip(device_ip)
-                sender.start(device)
-            elif data["type"] == "stop_capture":
-                sender.stop()
+            # data = json.loads(message)
+            # if data["type"] == "start_capture":
+            #     device_ip = data["device_ip"]
+            #     device = network_monitor.get_device_by_ip(device_ip)
+            #     await sender.start(device)
+            # elif data["type"] == "stop_capture":
+            #     await sender.stop()
 
     except WebSocketDisconnect:
-        sender.stop()
+        await sender.stop()
 
     except Exception as e:
         print(f"Error: {e}")
 
     finally:
-        sender.stop()
+        await sender.stop()
 
 
 @app.websocket("/monitor")

--- a/wavnes/monitoring_data_sender.py
+++ b/wavnes/monitoring_data_sender.py
@@ -5,22 +5,22 @@ class MonitoringDataSender:
     def __init__(self, network_monitor, websocket):
         self.network_monitor = network_monitor
         self.websocket = websocket
-        self.update_interval = 1
-        self.monitoring_task = None
+        self.monitoring_send_interval = 1
+        self.monitoring_sender_task = None
 
     async def start(self):
-        self.monitoring_task = asyncio.create_task(self._monitoring_loop())
+        self.monitoring_sender_task = asyncio.create_task(self._stats_send_loop())
 
     async def stop(self):
-        if self.monitoring_task:
-            self.monitoring_task.cancel()
+        if self.monitoring_sender_task:
+            self.monitoring_sender_task.cancel()
             try:
-                await self.monitoring_task
+                await self.monitoring_sender_task
             except asyncio.CancelledError:
                 pass
-            self.monitoring_task = None
+            self.monitoring_sender_task = None
 
-    async def _monitoring_loop(self):
+    async def _stats_send_loop(self):
         while True:
             devices = self.network_monitor.get_devices()
             try:
@@ -28,7 +28,7 @@ class MonitoringDataSender:
             except Exception as e:
                 print(f"Error sending device stats: {e}")
                 break
-            await asyncio.sleep(self.update_interval)
+            await asyncio.sleep(self.monitoring_send_interval)
 
     async def send_device_stats(self, devices):
         stat_data = []

--- a/wavnes/packet_data_sender.py
+++ b/wavnes/packet_data_sender.py
@@ -1,19 +1,65 @@
+import asyncio
+
+
 class PacketDataSender:
     def __init__(self, network_monitor, websocket, loop):
         self.network_monitor = network_monitor
         self.websocket = websocket
         self.loop = loop
         self.selected_device = None
+        self.prev_stat_info = None
+        self.stat_send_interval = 1
+        self.stat_sender_task = None
 
-    def start(self, device):
+    async def start(self, device):
         if self.selected_device:
             self.selected_device.sniffer.stop_packet_send()
+
         self.selected_device = device
         self.selected_device.sniffer.start_packet_send(
             self.websocket, self.loop)
+        self.stat_sender_task = asyncio.create_task(self._stat_send_loop())
 
-    def stop(self):
+    async def stop(self):
+        if self.stat_sender_task:
+            self.stat_sender_task.cancel()
+            try:
+                await self.stat_sender_task
+            except asyncio.CancelledError:
+                pass
+            self.stat_sender_task = None
+
         if self.selected_device:
             self.selected_device.sniffer.stop_packet_send()
             self.selected_device.sniffer.reset_time_info()
             self.selected_device = None
+
+    async def _stat_send_loop(self):
+        while True:
+            try:
+                await self.send_packet_stat()
+            except Exception as e:
+                print(f"Error sending packet stat: {e}")
+                break
+            await asyncio.sleep(self.stat_send_interval)
+
+    def _calc_stat_diff(self, cur_stat_info):
+        prev_stat_info = self.prev_stat_info
+        stat_diff = {
+            'send_pkt': cur_stat_info['send_pkt'] - prev_stat_info['send_pkt'],
+            'recv_pkt': cur_stat_info['recv_pkt'] - prev_stat_info['recv_pkt'],
+            'send_data': cur_stat_info['send_data'] - prev_stat_info['send_data'],
+            'recv_data': cur_stat_info['recv_data'] - prev_stat_info['recv_data'],
+        }
+        return stat_diff
+
+    async def send_packet_stat(self):
+        cur_stat_info = self.selected_device.get_stat_info()
+        if self.prev_stat_info == None:
+            self.prev_stat_info = cur_stat_info
+        stat_diff = self._calc_stat_diff(cur_stat_info)
+        await self.websocket.send_json({
+            'type': 'stat',
+            'data': stat_diff
+        })
+        self.prev_stat_info = cur_stat_info


### PR DESCRIPTION
## Issue
#60 

## Details
```python
from contextlib import asynccontextmanager

@asynccontextmanager
async def lifespan(app: FastAPI):
    await network_monitor.start()
    try:
        yield
    finally:
        pass


app = FastAPI(lifespan=lifespan)
```


FastAPI의 ``@asynccontextmanager`` 이용하여 lifespan 등록
시작시 ``network_monitor.start()``를 하도록.

그리고 스니핑은 NetworkMonitor에서 하게 하고
나머지는 Sender로 분류함. 이미 스니핑 되고 있는 데이터를 전송하는 기능만 담당하게 함.
