### PR TITLE
fix: 잘못 지정한 필드 이름 수정, make_packet_info 메서드 수정

### DIFF
--- a/wavnes/protocol_fields.py
+++ b/wavnes/protocol_fields.py
@@ -82,10 +82,7 @@ class UdpFields(ProtocolFields):
 
 class MqttFields(ProtocolFields):
     COMMON_FIELDS = [
-        ('msgtype', 4),
-        ('dupflag', 1),
-        ('qos', 1),
-        ('retain', 1),
+        ('hdrflags', 8),
         ('len', '~'),
     ]
     LAYER_NAME = 'MQTT'
@@ -93,10 +90,12 @@ class MqttFields(ProtocolFields):
     SPECIFIC_FIELDS = {
         "CONNECT": [
             ('proto_len', 16),
-            ('protoname', 8),
+            ('protoname', '~'),
+            ('ver', 8),
             ('conflag_uname', 1),
             ('conflag_passwd', 1),
-            ('conflag_qos', 1),
+            ('conflag_retain', 1),
+            ('conflag_qos', 2),
             ('conflag_willflag', 1),
             ('conflag_cleansess', 1),
             ('conflag_reserved', 1),

--- a/wavnes/utils.py
+++ b/wavnes/utils.py
@@ -132,3 +132,30 @@ def packet_to_dict(packet):
         pkt_dict[layer_name] = layer_dict
 
     return pkt_dict
+
+
+def make_packet_info(time_info, packet):
+    iot_protocol = ''
+    summary = ''
+    if 'mqtt' in packet:
+        iot_protocol = 'MQTT'
+        summary = packet.mqtt.msgtype.showname_value
+    elif 'coap' in packet:
+        iot_protocol = 'CoAP'
+        summary = packet.coap.code.showname_value
+
+    packet_info = {'type': 'packet',
+                   'data': {'info': {},
+                            'layers': {}}
+                   }
+    time_info.update(packet)
+    packet_info['data']['info'].update(time_info.get_time_info())
+    packet_info['data']['info'].update({'src': packet.ip.src})
+    packet_info['data']['info'].update({'dst': packet.ip.dst})
+    packet_info['data']['info'].update({'len': len(packet)})
+    packet_info['data']['info'].update({'protocol': iot_protocol})
+    packet_info['data']['info'].update({'summary': summary})
+
+    packet_info['data']['layers'].update(packet_to_dict(packet))
+
+    return packet_info


### PR DESCRIPTION
## Issues
#83 

## Details
이슈 말고도
잘못 지정해놓은 필드 이름 수정하고(pyshark의 패킷 객체에 지정된 필드 이름 확인하고 수정)

그리고 make_packet_info에서 info 필드에 time, src, dst, protocol, len, summary로 보내도록 수정.
원래는 time, protocol만 보냈었음

<img width="791" alt="image" src="https://github.com/Wave-Net/wavenet-backend/assets/52701529/86633490-9c57-496e-8936-3b3b1f3d049a">
